### PR TITLE
Fix integer overflow in cases with word boundaries and a zero length haystack

### DIFF
--- a/src/mvzr.zig
+++ b/src/mvzr.zig
@@ -781,7 +781,7 @@ fn matchGroup(patt: []const RegOp, sets: []const CharSet, haystack: []const u8, 
 
 fn matchWordBreak(patt: []const RegOp, sets: []const CharSet, haystack: []const u8, i: usize) ?OpMatch {
     if (i == haystack.len) {
-        if (isWordChar(haystack[i - 1])) {
+        if (i > 0 and isWordChar(haystack[i - 1])) {
             return OpMatch{ .i = i, .j = nextPattern(patt) };
         } else {
             return null;

--- a/src/mvzr.zig
+++ b/src/mvzr.zig
@@ -2464,3 +2464,7 @@ test "mandatory a fails on zero length haystack" {
 test "some == 0 is an optional for termination" {
     try testMatchAll("^[A-Za-z][0-9A-Za-z]{0,19}$", "x");
 }
+
+test "word boundary with zero length haystack" {
+    try testFail("\\b", "");
+}


### PR DESCRIPTION
**Disclaimer: This is my first time contributing to anybody else's github via a PR like this. My apologies if I'm screwing up some part of the process. Corrections/suggestions are welcome.**

# Problem
Trying to match a pattern with a word boundary in it to a zero length haystack causes an integer overflow error, as the matchWordBreak function assumes that the haystack is of non-zero length and subtracts 1 from the length.

Annotated code excerpt:
```zig
fn matchWordBreak(patt: []const RegOp, sets: []const CharSet, haystack: []const u8, i: usize) ?OpMatch {
    if (i == haystack.len) {
        if (isWordChar(haystack[i - 1])) { // <-- overflow occurs here
            return OpMatch{ .i = i, .j = nextPattern(patt) };
        } else {
            return null;
        }
    }
```
See also https://github.com/mnemnion/mvzr/blob/9a3290323db74207be60a0ebea730cebb938a0fe/src/mvzr.zig#L782C1-L790C1.

## Test

Commit 9a3290323db74207be60a0ebea730cebb938a0fe introduces a (minimal) test that triggers the integer overflow error, like so:
```zig
test "word boundary with zero length haystack" {
    try testFail("\\b", "");
}
```

Result of test:
```console
> zig build test --summary all                                                                                                                                                                                                                                                                                                      
test
└─ run test failure
thread 412700 panic: integer overflow
/home/arjen/repos/mvzr/src/mvzr.zig:784:35: 0x1083973 in matchWordBreak (test)
        if (isWordChar(haystack[i - 1])) {
                                  ^
/home/arjen/repos/mvzr/src/mvzr.zig:390:42: 0x1063211 in matchPattern (test)
            .word_break => matchWordBreak(this_patt, sets, haystack, i),
                                         ^
/home/arjen/repos/mvzr/src/mvzr.zig:303:28: 0x105f16b in matchOuterPattern (test)
        return matchPattern(patt, sets, haystack, i);
                           ^
/home/arjen/repos/mvzr/src/mvzr.zig:211:58: 0x10585f5 in matchInternal (test)
                        const matched = matchOuterPattern(patt, &regex.sets, haystack, matchlen);
                                                         ^
/home/arjen/repos/mvzr/src/mvzr.zig:115:54: 0x1051eee in match (test)
            const maybe_matched = regex.matchInternal(haystack);
                                                     ^
/home/arjen/repos/mvzr/src/mvzr.zig:2147:42: 0x10525c8 in testFail (test)
        try expectEqual(null, regex.match(haystack));
                                         ^
/home/arjen/repos/mvzr/src/mvzr.zig:2469:17: 0x1105dc4 in test.word boundary with zero length haystack (test)
    try testFail("\\b", "");
                ^
...
```

## (Proposed) Fix
Commit e6df64a411030d6fb34b9f9cdd68bd96e1a47cd0 introduces a fix for the issue (or a proposal for one, anyway), like so:
```diff
-        if (isWordChar(haystack[i - 1])) {
+        if (i > 0 and isWordChar(haystack[i - 1])) {
```

***

P.S.: I ran into some other issues with word boundaries (missed matches, not overflows), particularly when they occur after a + or * modifier, but it was not as easy to fix (or even for me to understand what is going wrong). Maybe I will create an issue for it.