### PR TITLE
Replace `**` with `@splat`

### DIFF
--- a/src/mvzr.zig
+++ b/src/mvzr.zig
@@ -101,8 +101,8 @@ pub const Regex: type = SizedRegex(MAX_REGEX_OPS, MAX_CHAR_SETS);
 
 pub fn SizedRegex(ops: comptime_int, char_sets: comptime_int) type {
     return struct {
-        patt: [ops]RegOp = [1]RegOp{.{ .unused = {} }} ** ops,
-        sets: [char_sets]CharSet = [1]CharSet{.{ .low = 0, .hi = 0 }} ** char_sets,
+        patt: [ops]RegOp = @splat(.{ .unused = {} }),
+        sets: [char_sets]CharSet = @splat(.{ .low = 0, .hi = 0 }),
 
         const SizedRegexT = @This();
 
@@ -2311,11 +2311,11 @@ test "match some things" {
     try testMatchAll("^[a-zA-Z0-9_!#$%&.-]+@([a-zA-Z0-9.-])+$", "myname.myfirst_name@gmail.com");
 
     // Non-catastropic backtracking #1
-    try testFail("(a+a+)+b", "a" ** 2048);
+    try testFail("(a+a+)+b", @as([2048]u8, @splat("a")));
     // Non-catastropic backtracking #2
-    try testFail("(a+?a+?)+?b", "a" ** 2048);
+    try testFail("(a+?a+?)+?b", @as([2048]u8, @splat("a")));
     // Non-catastropic backtracking #3
-    try testFail("^(.*?,){254}P", "12345," ** 255);
+    try testFail("^(.*?,){254}P", @as([1530]u8, @splat("12345,")));
 }
 
 test "heap allocated regex and match" {


### PR DESCRIPTION
Array multiplication has been removed in https://codeberg.org/ziglang/zig/pulls/32130

Fixes a compile error when building mvzr with the latest zig version (master branch):

```bash
zig-pkg/mvzr-0.3.9-ZSOky6t2AQCA7efmm5EYbPb5sOdbXa4EFsUgYbQ6hZv9/src/mvzr.zig:104:56: error: binary operator '*' has whitespace on one side, but not the other
        patt: [ops]RegOp = [1]RegOp{.{ .unused = {} }} ** ops,
                                                       ^
error: 1 compilation errors
```